### PR TITLE
Extraer mención a resultados garantizados

### DIFF
--- a/src/app/components/FeedbackForm.tsx
+++ b/src/app/components/FeedbackForm.tsx
@@ -303,7 +303,7 @@ const FeedbackForm: React.FC<FeedbackFormProps> = ({ defaultService = 'general' 
               </li>
               <li className="flex items-center gap-2">
                 <span className="text-[#FFD700]">✓</span>
-                Resultados garantizados
+                Compromiso total
               </li>
             </ul>
           </div>

--- a/src/app/servicios/accidentes-transito/page.tsx
+++ b/src/app/servicios/accidentes-transito/page.tsx
@@ -64,7 +64,7 @@ export default function AccidentesdeTránsitoPage() {
             </div>
             
             <div>
-              <h2 className="font-medium text-[#1B1743] mb-2">Resultados garantizados</h2>
+              <h2 className="font-medium text-[#1B1743] mb-2">Compromiso total</h2>
               <p className="text-sm md:text-[1.48vh] leading-5 md:leading-[2.22vh] font-medium">
                 Nuestro objetivo es obtener los mejores resultados para nuestros clientes, protegiendo siempre sus derechos.
               </p>

--- a/src/app/servicios/asesoramiento-empresas/page.tsx
+++ b/src/app/servicios/asesoramiento-empresas/page.tsx
@@ -64,7 +64,7 @@ export default function AsesoramientoEmpresarialPage() {
             </div>
             
             <div>
-              <h2 className="font-medium text-[#1B1743] mb-2">Resultados garantizados</h2>
+              <h2 className="font-medium text-[#1B1743] mb-2">Compromiso total</h2>
               <p className="text-sm md:text-[1.48vh] leading-5 md:leading-[2.22vh] font-medium">
                 Nuestro objetivo es obtener los mejores resultados para nuestros clientes, protegiendo siempre sus derechos.
               </p>

--- a/src/app/servicios/ciudadania/page.tsx
+++ b/src/app/servicios/ciudadania/page.tsx
@@ -64,7 +64,7 @@ export default function CiudadaníaPage() {
             </div>
             
             <div>
-              <h2 className="font-medium text-[#1B1743] mb-2">Resultados garantizados</h2>
+              <h2 className="font-medium text-[#1B1743] mb-2">Compromiso total</h2>
               <p className="text-sm md:text-[1.48vh] leading-5 md:leading-[2.22vh] font-medium">
                 Nuestro objetivo es obtener los mejores resultados para nuestros clientes, protegiendo siempre sus derechos.
               </p>

--- a/src/app/servicios/defensas-penales/page.tsx
+++ b/src/app/servicios/defensas-penales/page.tsx
@@ -64,7 +64,7 @@ export default function DefensasPenalesPage() {
             </div>
             
             <div>
-              <h2 className="font-medium text-[#1B1743] mb-2">Resultados garantizados</h2>
+              <h2 className="font-medium text-[#1B1743] mb-2">Compromiso total</h2>
               <p className="text-sm md:text-[1.48vh] leading-5 md:leading-[2.22vh] font-medium">
                 Nuestro objetivo es obtener los mejores resultados para nuestros clientes, protegiendo siempre sus derechos.
               </p>

--- a/src/app/servicios/despidos/page.tsx
+++ b/src/app/servicios/despidos/page.tsx
@@ -65,7 +65,7 @@ export default function DespidosPage() {
             </div>
             
             <div>
-              <h2 className="font-medium text-[#1B1743] mb-2">Resultados garantizados</h2>
+              <h2 className="font-medium text-[#1B1743] mb-2">Compromiso total</h2>
               <p className="text-sm md:text-[1.48vh] leading-5 md:leading-[2.22vh] font-medium">
                 Nuestro objetivo es obtener los mejores resultados para nuestros clientes, protegiendo siempre sus derechos.
               </p>

--- a/src/app/servicios/divorcios/page.tsx
+++ b/src/app/servicios/divorcios/page.tsx
@@ -64,7 +64,7 @@ export default function DivorciosPage() {
             </div>
             
             <div>
-              <h2 className="font-medium text-[#1B1743] mb-2">Resultados garantizados</h2>
+              <h2 className="font-medium text-[#1B1743] mb-2">Compromiso total</h2>
               <p className="text-sm md:text-[1.48vh] leading-5 md:leading-[2.22vh] font-medium">
                 Nuestro objetivo es obtener los mejores resultados para nuestros clientes, protegiendo siempre sus derechos.
               </p>

--- a/src/app/servicios/enfermedades-laborales/page.tsx
+++ b/src/app/servicios/enfermedades-laborales/page.tsx
@@ -64,7 +64,7 @@ export default function EnfermedadesLaboralesPage() {
             </div>
             
             <div>
-              <h2 className="font-medium text-[#1B1743] mb-2">Resultados garantizados</h2>
+              <h2 className="font-medium text-[#1B1743] mb-2">Compromiso total</h2>
               <p className="text-sm md:text-[1.48vh] leading-5 md:leading-[2.22vh] font-medium">
                 Nuestro objetivo es obtener los mejores resultados para nuestros clientes, protegiendo siempre sus derechos.
               </p>

--- a/src/app/servicios/page.tsx
+++ b/src/app/servicios/page.tsx
@@ -200,7 +200,7 @@ const ServiciosPage = () => {
               </div>
               
               <div className="bg-white border border-gray-200 rounded-lg p-6 hover:shadow-md transition-shadow">
-                <h4 className="font-semibold text-[#1B1743] mb-2">Resultados garantizados</h4>
+                <h4 className="font-semibold text-[#1B1743] mb-2">Compromiso total</h4>
                 <p className="text-sm md:text-[1.48vh] leading-5 md:leading-[2.22vh] font-medium">
                   Nuestro objetivo es obtener los mejores resultados para nuestros clientes, protegiendo siempre sus derechos.
                 </p>

--- a/src/app/servicios/sucesiones/page.tsx
+++ b/src/app/servicios/sucesiones/page.tsx
@@ -64,7 +64,7 @@ export default function SucesionesPage() {
             </div>
             
             <div>
-              <h2 className="font-medium text-[#1B1743] mb-2">Resultados garantizados</h2>
+              <h2 className="font-medium text-[#1B1743] mb-2">Compromiso total</h2>
               <p className="text-sm md:text-[1.48vh] leading-5 md:leading-[2.22vh] font-medium">
                 Nuestro objetivo es obtener los mejores resultados para nuestros clientes, protegiendo siempre sus derechos.
               </p>

--- a/src/app/servicios/trabajo-negro/page.tsx
+++ b/src/app/servicios/trabajo-negro/page.tsx
@@ -64,7 +64,7 @@ export default function TrabajoenNegroPage() {
             </div>
             
             <div>
-              <h2 className="font-medium text-[#1B1743] mb-2">Resultados garantizados</h2>
+              <h2 className="font-medium text-[#1B1743] mb-2">Compromiso total</h2>
               <p className="text-sm md:text-[1.48vh] leading-5 md:leading-[2.22vh] font-medium">
                 Nuestro objetivo es obtener los mejores resultados para nuestros clientes, protegiendo siempre sus derechos.
               </p>


### PR DESCRIPTION
Replaced "Resultados garantizados" with "Compromiso total" across the site to avoid problematic legal/ethical implications of guaranteeing results.

---
<a href="https://cursor.com/background-agent?bcId=bc-505d2b0d-f8e2-4b33-856e-d89facc06b5d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-505d2b0d-f8e2-4b33-856e-d89facc06b5d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

